### PR TITLE
add ErrorMessage#as_json

### DIFF
--- a/lib/active_model/error_collecting/error_message.rb
+++ b/lib/active_model/error_collecting/error_message.rb
@@ -67,6 +67,10 @@ module ActiveModel
         }
       end
 
+      def as_json(*json_args)
+        to_hash
+      end
+
       def hash
         to_hash.hash
       end

--- a/spec/lib/active_model/error_collecting/error_message_spec.rb
+++ b/spec/lib/active_model/error_collecting/error_message_spec.rb
@@ -263,6 +263,22 @@ describe ActiveModel::ErrorCollecting::ErrorMessage do
     its(:attribute) { should == attribute }
   end
 
+  describe '#to_hash' do
+    let(:message) { :invalid }
+    let(:options) { {} }
+
+    its(:to_hash) { should == { attribute: attribute, type: :invalid, message: nil, options: {} } }
+  end
+
+  describe '#as_json' do
+    let(:message) { :invalid }
+    let(:options) { {} }
+
+    it "should respond to as_json taking json arguments" do
+      subject.as_json(test: :arguments).should == { attribute: attribute, type: :invalid, message: nil, options: {} }
+    end
+  end
+
   describe '#<=>' do
     subject { e1 <=> e2 }
 


### PR DESCRIPTION
We're using this internally in our testing and tools, I figured it might be generally useful
