### PR TITLE
forward more methods to the collection in the emulation layer

### DIFF
--- a/lib/active_model/better_errors/emulation.rb
+++ b/lib/active_model/better_errors/emulation.rb
@@ -12,9 +12,11 @@ module ActiveModel
     # The ActiveModel Emulation Layer
     #
     module Emulation
+      include Enumerable
+
       MODEL_METHODS = [
         :clear, :include?, :get, :set, :delete, :[], :[]=,
-        :each, :size, :values, :keys, :count, :empty?, :any?,
+        :each, :size, :length, :values, :keys, :count, :empty?, :any?,
         :added?, :entries
       ]
 


### PR DESCRIPTION
We already forward `each` to the collection, so including `Enumerable`
allows more code written against the original ActiveModel
ErrorCollection class to continue working without modification.
